### PR TITLE
Update accessor.js

### DIFF
--- a/src/accessor.js
+++ b/src/accessor.js
@@ -48,6 +48,18 @@ var Accessor = function(config, single, plural){
         })
       })
     },
+    
+    createOrUpdate: function(data){
+      var createData = {}
+      createData[single] = data
+      return new Promise(function(fufill, reject){
+        zdrequest.post('/' + plural + '/create_or_update.json', createData).then(function(data){
+          fufill(data)
+        }).catch(function(err){
+          reject(err)
+        })
+      })
+    },
 
     update: function(id, data){
       var createData = {}


### PR DESCRIPTION
Adding the createOrUpdate for the Users, cause most of the time we update user based on the email, so we don't need to call SHOW to know if exist...
Zendesk server will answer error if any other object (Ticket, organisation, ...)